### PR TITLE
Profiles+Gastronet+KRG: Remove Lesion from base + Gastronet profile

### DIFF
--- a/Gastronet profiles/GastronetDiagnosticReport.StructureDefinition.xml
+++ b/Gastronet profiles/GastronetDiagnosticReport.StructureDefinition.xml
@@ -53,14 +53,6 @@
       <path value="DiagnosticReport.specimen" />
       <max value="0" />
     </element>
-    <element id="DiagnosticReport.result:Lesion">
-      <path value="DiagnosticReport.result" />
-      <sliceName value="Lesion" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet" />
-      </type>
-    </element>
     <element id="DiagnosticReport.result:BostonBowelPreparationScale">
       <path value="DiagnosticReport.result" />
       <sliceName value="BostonBowelPreparationScale" />

--- a/Profiles/DiagnosticReport.StructureDefinition.xml
+++ b/Profiles/DiagnosticReport.StructureDefinition.xml
@@ -64,15 +64,6 @@
         <rules value="open" />
       </slicing>
     </element>
-    <element id="DiagnosticReport.result:Lesion">
-      <path value="DiagnosticReport.result" />
-      <sliceName value="Lesion" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-lesion" />
-      </type>
-      <mustSupport value="true" />
-    </element>
     <element id="DiagnosticReport.result:BostonBowelPreparationScale">
       <path value="DiagnosticReport.result" />
       <sliceName value="BostonBowelPreparationScale" />

--- a/Registry profiles/KRGDiagnosticReport.StructureDefinition.xml
+++ b/Registry profiles/KRGDiagnosticReport.StructureDefinition.xml
@@ -53,14 +53,6 @@
       <path value="DiagnosticReport.specimen" />
       <max value="0" />
     </element>
-    <element id="DiagnosticReport.result:Lesion">
-      <path value="DiagnosticReport.result" />
-      <sliceName value="Lesion" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-lesion-krg" />
-      </type>
-    </element>
     <element id="DiagnosticReport.result:BostonBowelPreparationScale">
       <path value="DiagnosticReport.result" />
       <sliceName value="BostonBowelPreparationScale" />
@@ -76,6 +68,15 @@
         <code value="Reference" />
         <targetProfile value="http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-numberoflesions-krg" />
       </type>
+    </element>
+    <element id="DiagnosticReport.result:Lesion">
+      <path value="DiagnosticReport.result" />
+      <sliceName value="Lesion" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-lesion-krg" />
+      </type>
+      <mustSupport value="true" />
     </element>
     <element id="DiagnosticReport.imagingStudy">
       <path value="DiagnosticReport.imagingStudy" />


### PR DESCRIPTION
This patch removes DiagnosticReport.result:Lesion from the base and
Gastronet Profile.

In addition it makes sure that DiagnosticReport.result:Lesion is still
set to mustSupport=true for KRGDiagnosticReport profile.