### PR TITLE
Profiles+Gastronet: Remove entry:Lesion and change Canonical Url for ValueSet No-procedure-reason-colonoscopy-Gastrone

### DIFF
--- a/Gastronet profiles/GastronetBundle.StructureDefinition.xml
+++ b/Gastronet profiles/GastronetBundle.StructureDefinition.xml
@@ -186,34 +186,6 @@
       <path value="Bundle.entry.response" />
       <max value="0" />
     </element>
-    <element id="Bundle.entry:Lesion">
-      <path value="Bundle.entry" />
-      <sliceName value="Lesion" />
-    </element>
-    <element id="Bundle.entry:Lesion.link">
-      <path value="Bundle.entry.link" />
-      <max value="0" />
-    </element>
-    <element id="Bundle.entry:Lesion.resource">
-      <path value="Bundle.entry.resource" />
-      <min value="1" />
-      <type>
-        <code value="Resource" />
-        <profile value="http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet" />
-      </type>
-    </element>
-    <element id="Bundle.entry:Lesion.search">
-      <path value="Bundle.entry.search" />
-      <max value="0" />
-    </element>
-    <element id="Bundle.entry:Lesion.request">
-      <path value="Bundle.entry.request" />
-      <max value="0" />
-    </element>
-    <element id="Bundle.entry:Lesion.response">
-      <path value="Bundle.entry.response" />
-      <max value="0" />
-    </element>
     <element id="Bundle.entry:NumberOfLesions">
       <path value="Bundle.entry" />
       <sliceName value="NumberOfLesions" />

--- a/Gastronet profiles/GastronetColonoscopy.StructureDefinition.xml
+++ b/Gastronet profiles/GastronetColonoscopy.StructureDefinition.xml
@@ -85,6 +85,13 @@
       <path value="Procedure.asserter" />
       <max value="0" />
     </element>
+    <element id="Procedure.reasonCode">
+      <path value="Procedure.reasonCode" />
+      <binding>
+        <strength value="required" />
+        <valueSet value="http://ehelse.no/fhir/valueset/no-colonoscopy-procedure-reason-gastronet" />
+      </binding>
+    </element>
     <element id="Procedure.reasonReference">
       <path value="Procedure.reasonReference" />
       <max value="0" />

--- a/Profiles/Bundle.StructureDefinition.xml
+++ b/Profiles/Bundle.StructureDefinition.xml
@@ -157,18 +157,6 @@
         <profile value="http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-diagnosticreport" />
       </type>
     </element>
-    <element id="Bundle.entry:Lesion">
-      <path value="Bundle.entry" />
-      <sliceName value="Lesion" />
-    </element>
-    <element id="Bundle.entry:Lesion.resource">
-      <path value="Bundle.entry.resource" />
-      <min value="1" />
-      <type>
-        <code value="Resource" />
-        <profile value="http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-lesion" />
-      </type>
-    </element>
     <element id="Bundle.entry:NumberOfLesions">
       <path value="Bundle.entry" />
       <sliceName value="NumberOfLesions" />

--- a/Profiles/ColonoscopyProcedure.StructureDefinition.xml
+++ b/Profiles/ColonoscopyProcedure.StructureDefinition.xml
@@ -491,10 +491,6 @@
     <element id="Procedure.reasonCode">
       <path value="Procedure.reasonCode" />
       <mustSupport value="true" />
-      <binding>
-        <strength value="required" />
-        <valueSet value="http://ehelse.no/fhir/valueset/no-colonoscopy-procedure-reason" />
-      </binding>
       <mapping>
         <identity value="no-colonoscopy-report" />
         <map value="11" />

--- a/ValueSets/No_procedure_reason_colonoscopy_GN.json
+++ b/ValueSets/No_procedure_reason_colonoscopy_GN.json
@@ -7,10 +7,10 @@
     },
     "text": {
         "status": "additional",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>Colonoscopy Report Indictation</h2><tt>http://ehelse.no/fhir/ValueSet/no-procedure-reason-coloscopy</tt></div>"
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>Colonoscopy Report Indictation</h2><tt>http://ehelse.no/fhir/valueset/no-colonoscopy-procedure-reason-gastronet</tt></div>"
     },
-    "url": "http://ehelse.no/fhir/valueset/no-colonoscopy-procedure-reason",
-    "name": "No-procedure-reason-colonoscopy",
+    "url": "http://ehelse.no/fhir/valueset/no-colonoscopy-procedure-reason-gastronet",
+    "name": "No-procedure-reason-colonoscopy-Gastronet",
     "title": "Colonoscopy Report Indication",
     "status": "draft",
     "publisher": "Norwegian Directorate of e-health",


### PR DESCRIPTION
### [Profiles+Gastronet: Remove entry:Lesion from Bundle profile](https://github.com/HL7Norway/Tarmkreftscreening/commit/fcbd1c84abb5875a1af3bb98093e7da7e0a2f7ce)

### [Profiles+Gastronet: Change canonical url for ValueSet](https://github.com/HL7Norway/Tarmkreftscreening/commit/5b8f86ad563a0afddeb6878d2ae937b50d3136c3)

This patch changes the canonical url for ValueSet
'No-procedure-reason-colonoscopy-Gastronet'
from: http://ehelse.no/fhir/valueset/no-colonoscopy-procedure-reason
to: http://ehelse.no/fhir/valueset/no-colonoscopy-procedure-reason-gastronet
