### PR TITLE
ValueSets: Change value of SNOMED Code 'Rekotisgmoid junction'

### DIFF
--- a/ValueSets/No_colonoscopy_segment_lesion.json
+++ b/ValueSets/No_colonoscopy_segment_lesion.json
@@ -208,7 +208,7 @@
                         ]
                     },
                     {
-                        "code": "81922002",
+                        "code": "49832006",
                         "display": "Rektosigmoid overgang",
                         "designation": [
                             {

--- a/ValueSets/No_colonoscopy_segment_reached.json
+++ b/ValueSets/No_colonoscopy_segment_reached.json
@@ -208,7 +208,7 @@
                         ]
                     },
                     {
-                        "code": "81922002",
+                        "code": "49832006",
                         "display": "Rektosigmoid overgang",
                         "designation": [
                             {

--- a/ValueSets/No_coloscopy_segment_reached.json
+++ b/ValueSets/No_coloscopy_segment_reached.json
@@ -213,7 +213,7 @@
                         ]
                     },
                     {
-                        "code": "81922002",
+                        "code": "49832006",
                         "display": "Rektosigmoid overgang",
                         "designation": [
                             {


### PR DESCRIPTION
This patch changes the value of the SNOMED Code 'Rektossigmoid junction'
from '81922002' to '49832006'

Norwegian translation 'Rektosigmoid overgang'