### PR TITLE
ValueSets+Profiles: Change code + cardinality

### DIFF
--- a/Profiles/ColonoscopyProcedure.StructureDefinition.xml
+++ b/Profiles/ColonoscopyProcedure.StructureDefinition.xml
@@ -42,7 +42,6 @@
       <short value="The concequence of the complications that have occured during the procedure" />
       <definition value="The concequence of the complications that have occured during the procedure" />
       <min value="0" />
-      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-complicationconsequence-extension" />

--- a/ValueSets/No_colonoscopy_segment_lesion.json
+++ b/ValueSets/No_colonoscopy_segment_lesion.json
@@ -256,7 +256,7 @@
                         ]
                     },
                     {
-                        "code": "34381000",
+                        "code": "53505006",
                         "display": "Analkanal/anus",
                         "designation": [
                             {


### PR DESCRIPTION
#### ValueSets: Change code 34381000 to 53505006
This patch changes the code 34381000 to 53505006 in ValueSet with name
'No-colonoscopy-segment-lesion' and canonical url:
'http://ehelse.no/fhir/ValueSet/no-colonoscopy-segment-lesion'

#### Profiles: Change cardinality of complicationConsequence to 0..*
This changes the cardinality of extension complicationConsequence from
0..1 to 0..* on base profile with canonical url:
'http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-colonoscopy'.