### PR TITLE
Profiles: Set cardinality 1..1 for NPK and 0..1 for SNOMED-CT

### DIFF
--- a/Profiles/SubProcedure.StructureDefinition.xml
+++ b/Profiles/SubProcedure.StructureDefinition.xml
@@ -58,12 +58,12 @@
     <element id="Procedure.code.coding:NKPK">
       <path value="Procedure.code.coding" />
       <sliceName value="NKPK" />
+      <min value="1" />
       <mustSupport value="true" />
     </element>
     <element id="Procedure.code.coding:SNOMED-CT">
       <path value="Procedure.code.coding" />
       <sliceName value="SNOMED-CT" />
-      <min value="1" />
       <mustSupport value="true" />
     </element>
     <element id="Procedure.subject">


### PR DESCRIPTION
This changes the previously set cardinality:
- coding:NPK 0..1 -> 1..1
- coding:SNOMED-CT 1..1 -> 0..1