### PR TITLE
ValueSets: Revert previously removal of code 49832006

### DIFF
--- a/ValueSets/No_colonoscopy_segment_reached.json
+++ b/ValueSets/No_colonoscopy_segment_reached.json
@@ -208,6 +208,30 @@
                         ]
                     },
                     {
+                        "code": "49832006",
+                        "display": "Rektosigmoid overgang",
+                        "designation": [
+                            {
+                                "language": "en",
+                                "use": {
+                                    "system": "http://snomed.info/sct",
+                                    "code": "900000000000003001",
+                                    "display": "Fully specified name"
+                                },
+                                "value": "Rectosigmoid structure (body structure)"
+                            },
+                            {
+                                "language": "no",
+                                "use": {
+                                    "system": "http://snomed.info/sct",
+                                    "code": "900000000000003001",
+                                    "display": "Fully specified name"
+                                },
+                                "value": "rectosigmoid overgang"
+                            }
+                        ]
+                    },
+                    {
                         "code": "34402009",
                         "display": "Rektum",
                         "designation": [


### PR DESCRIPTION
This reverts commit 3372adfc795cb2f1a5152fd851d0e2ae8d5ab447.

Reverts previous removal of code 49832006 - Rectosigmoid structure (body structure).